### PR TITLE
Add the name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "gearman"
 maintainer       "Cramer Development"
 maintainer_email "sysadmin@cramerdev.com"
 license          "Apache 2.0"


### PR DESCRIPTION
The name attribute is [required](https://docs.chef.io/config_rb_metadata.html) so attempting to use this cookbook without this parameter results into failure.
